### PR TITLE
show all urls if host='0.0.0.0'

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,11 +23,31 @@ const launch = (options, callback) => {
 
   const serverCb = () => {
     clearTimeout(customServerTimeout);
-    const isCustom = serverPath || serverCommand;
-    if (isCustom) {
-      if (startupLogging) logger.info('custom server started, initializing watcher');
-    } else {
-      if (startupLogging) logger.info(`application started on http://${host}:${port}/`);
+    if (startupLogging) {
+      if (serverPath || serverCommand) {
+        logger.info('custom server started, initializing watcher');
+      } else {
+        let ifshow;
+
+        // show ipv4 urls
+        if (host === '0.0.0.0') {
+          const os = require('os');
+          const ifaces = os.networkInterfaces();
+          Object.keys(ifaces).forEach(function (ifname) {
+            let alias = 0;
+            ifaces[ifname].forEach(function (iface) {
+              if ('IPv4' === iface.family) { // && iface.internal == false) {
+                ifshow = (alias > 0) ? `${ifname}:${alias}` : ifname;
+                logger.info(`application started on http://${iface.address}:${port}/ (${ifshow})`);
+                alias++;
+              }
+            });
+          });
+        }
+
+        // ensure a url is always shown
+        if (!ifshow) logger.info(`application started on http://${host}:${port}/`);
+      }
     }
     callback(null, server);
   };


### PR DESCRIPTION
If host='0.0.0.0', the http server will listen on all ips. However,
these ips are not always fixed or known. Instead of searching for them,
this will now show the urls that are accessible from other devices on
the network.
